### PR TITLE
[01] 로그인 페이지 인증구현

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,9 +1,17 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 // import Navbar from "../Navbar";
 import LoginPage from "../components/LoginPage";
+import { useDispatch } from "react-redux";
+import { refresh } from "../features/userSlice";
 
 function App() {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(refresh());
+  }, []);
+
   return (
     <BrowserRouter>
       <Routes>

--- a/src/features/userSlice.js
+++ b/src/features/userSlice.js
@@ -20,7 +20,6 @@ export const userSlice = createSlice({
       state.loginLoading = false;
       state.loginSucceed = true;
       state.loginError = null;
-      console.log(111, action);
       state.user = action.payload;
     },
     loginFailed: (state, action) => {
@@ -33,9 +32,10 @@ export const userSlice = createSlice({
       state.loginSucceed = false;
       state.loginError = null;
     },
+    refresh: state => state,
   },
 });
 
-export const { loginRequest, loginSucceed, loginFailed, join } =
+export const { loginRequest, loginSucceed, loginFailed, join, refresh } =
   userSlice.actions;
 export default userSlice.reducer;


### PR DESCRIPTION
# [01] 로그인 페이지 인증구현
## 노션 칸반 링크
- [Post 로그인](https://www.notion.so/vanillacoding/Task-Post-743d4d56cf1a45c9b18b156444f84005)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: 로그인단 인증 구현
- refresh Token 자동 인증 구현


## 테스트 방법
-
-
## 기타 사항
- 현재 accessToken을 받으면, 해당 토큰 만료 1분전에 재발급 하도록 setTimeout()으로 구현.
- 또한 최상위 App에서 useEffect()로 같은 로직을 사용하여, 새로고침 시, 자동 로그인이 되도록 구현.
- setTimeout이 중복으로 겹치는 경우가 발생할 것 같음. 해결 방안 모색중
