### PR TITLE
[15] 달력페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/react": "^12.1.2",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^0.25.0",
+        "date-fns": "^2.28.0",
         "firebase": "^9.6.6",
         "lint-staged": "^12.3.3",
         "prop-types": "^15.8.1",
@@ -6240,6 +6241,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {
@@ -20492,6 +20505,11 @@
           }
         }
       }
+    },
+    "date-fns": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "debug": {
       "version": "4.3.3",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.25.0",
+    "date-fns": "^2.28.0",
     "firebase": "^9.6.6",
     "lint-staged": "^12.3.3",
     "prop-types": "^15.8.1",

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -11,6 +11,7 @@ import axios from "axios";
 import MandalPage from "../components/MandalPage";
 import LoginPage from "../components/LoginPage";
 import MainGoalLists from "../components/mainGoal/MainGoalLists";
+import CalenderPage from "../components/CalendarPage";
 
 axios.defaults.withCredentials = true;
 
@@ -32,10 +33,11 @@ function App() {
         {/* <Route path="/" element={} /> */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/mainGoal/:id" element={<MandalPage />} />
+        <Route path="/calendar" element={<CalenderPage />} />
       </Routes>
       <AppContainer>
-        <MainGoalLists />
-        <Navbar />
+        {/* <MainGoalLists /> */}
+        {/* <Navbar /> */}
       </AppContainer>
     </BrowserRouter>
   );

--- a/src/app/App.js
+++ b/src/app/App.js
@@ -6,12 +6,12 @@ import styled from "styled-components";
 import Navbar from "../Navbar";
 import { refresh } from "../features/userSlice";
 
-import MainGoalPage from "../components/MainGoalPage";
+import MainMandal from "../components/MainMandal";
 import axios from "axios";
 import MandalPage from "../components/MandalPage";
 import LoginPage from "../components/LoginPage";
 import MainGoalLists from "../components/mainGoal/MainGoalLists";
-import CalenderPage from "../components/CalendarPage";
+import CalendarPage from "../components/CalendarPage";
 
 axios.defaults.withCredentials = true;
 
@@ -33,7 +33,7 @@ function App() {
         {/* <Route path="/" element={} /> */}
         <Route path="/login" element={<LoginPage />} />
         <Route path="/mainGoal/:id" element={<MandalPage />} />
-        <Route path="/calendar" element={<CalenderPage />} />
+        <Route path="/calendar" element={<CalendarPage />} />
       </Routes>
       <AppContainer>
         {/* <MainGoalLists /> */}

--- a/src/components/CalendarBox.js
+++ b/src/components/CalendarBox.js
@@ -2,29 +2,28 @@ import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
-const DateContainder = styled.div`
-  border: solid black 1px;
+const DateContainer = styled.div`
+  border: 1px solid black;
   border-collapse: collapse;
   width: 100px;
   height: 600px;
 `;
 
 const DateBox = styled.div`
-  border-top: solid black 1px;
+  border-top: 1px solid black;
   text-align: center;
 `;
 
-export default function CalenderBox({ day, date, todo }) {
-  console.log(date, todo);
+export default function CalendarBox({ day, date, todo }) {
   return (
-    <DateContainder>
+    <DateContainer>
       {day}
       <DateBox>{date}</DateBox>
-    </DateContainder>
+    </DateContainer>
   );
 }
 
-CalenderBox.propTypes = {
+CalendarBox.propTypes = {
   day: PropTypes.string.isRequired,
   date: PropTypes.string,
   todo: PropTypes.instanceOf(Array),

--- a/src/components/CalendarBox.js
+++ b/src/components/CalendarBox.js
@@ -1,0 +1,31 @@
+import React from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+const DateContainder = styled.div`
+  border: solid black 1px;
+  border-collapse: collapse;
+  width: 100px;
+  height: 600px;
+`;
+
+const DateBox = styled.div`
+  border-top: solid black 1px;
+  text-align: center;
+`;
+
+export default function CalenderBox({ day, date, todo }) {
+  console.log(date, todo);
+  return (
+    <DateContainder>
+      {day}
+      <DateBox>{date}</DateBox>
+    </DateContainder>
+  );
+}
+
+CalenderBox.propTypes = {
+  day: PropTypes.string.isRequired,
+  date: PropTypes.string,
+  todo: PropTypes.instanceOf(Array),
+};

--- a/src/components/CalendarPage.js
+++ b/src/components/CalendarPage.js
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { format, add, getDay } from "date-fns";
+import CalenderBox from "./CalendarBox";
+import styled from "styled-components";
+import axios from "axios";
+
+const Container = styled.div`
+  display: flex;
+  margin-bottom: 20px;
+  justify-content: center;
+  align-items: center;
+  border-collapse: collapse;
+`;
+
+export default function CalendarPage() {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const [todos, setTodos] = useState([]);
+  const loginState = useSelector(state => state.user.loginSucceed);
+
+  const WEEK = ["일", "화", "수", "목", "금", "토", "월"];
+  const handleLeft = () => {
+    setCurrentDate(add(currentDate, { days: -7 }));
+  };
+  const handleRight = () => {
+    setCurrentDate(add(currentDate, { days: 7 }));
+  };
+
+  const goToday = () => {
+    setCurrentDate(new Date());
+  };
+
+  const getUsersTodo = async id => {
+    const currentSunday = add(currentDate, { days: -1 * getDay(currentDate) });
+    const res = await axios.get("/api/todos", {
+      headers: {
+        currentDate: format(currentSunday, "yyyy-MM-dd"),
+      },
+    });
+
+    if (res.data.result === "error") {
+      return;
+    }
+
+    setTodos(res.data.result);
+  };
+
+  const showCalender = () => {
+    return WEEK.map((day, i) => {
+      const date = format(
+        add(currentDate, { days: -1 * getDay(currentDate) + i }),
+        "yyyy-MM-dd",
+      );
+
+      return (
+        <CalenderBox day={day} date={date} key={date} todo={todos?.[date]} />
+      );
+    });
+  };
+
+  useEffect(() => {
+    if (loginState) {
+      getUsersTodo();
+    }
+  }, [loginState]);
+
+  return (
+    <div>
+      <Container>
+        <div onClick={goToday}>오늘</div>
+        <div onClick={handleLeft}>{`<`}</div>
+        {format(currentDate, "yyyy년 MM월")}
+        <div onClick={handleRight}>{`>`}</div>
+      </Container>
+      <Container>{showCalender()}</Container>
+    </div>
+  );
+}

--- a/src/components/CalendarPage.js
+++ b/src/components/CalendarPage.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { format, add, getDay } from "date-fns";
-import CalenderBox from "./CalendarBox";
+import CalendarBox from "./CalendarBox";
 import styled from "styled-components";
 import axios from "axios";
 
@@ -18,11 +18,11 @@ export default function CalendarPage() {
   const [todos, setTodos] = useState([]);
   const loginState = useSelector(state => state.user.loginSucceed);
 
-  const WEEK = ["일", "화", "수", "목", "금", "토", "월"];
-  const handleLeft = () => {
+  const WEEK = ["일", "월", "화", "수", "목", "금", "토"];
+  const handlePrevButtonClick = () => {
     setCurrentDate(add(currentDate, { days: -7 }));
   };
-  const handleRight = () => {
+  const handleNextButtonClick = () => {
     setCurrentDate(add(currentDate, { days: 7 }));
   };
 
@@ -31,10 +31,10 @@ export default function CalendarPage() {
   };
 
   const getUsersTodo = async id => {
-    const currentSunday = add(currentDate, { days: -1 * getDay(currentDate) });
+    const weekStart = add(currentDate, { days: -1 * getDay(currentDate) });
     const res = await axios.get("/api/todos", {
       headers: {
-        currentDate: format(currentSunday, "yyyy-MM-dd"),
+        currentDate: format(weekStart, "yyyy-MM-dd"),
       },
     });
 
@@ -45,7 +45,7 @@ export default function CalendarPage() {
     setTodos(res.data.result);
   };
 
-  const showCalender = () => {
+  const showCalendar = () => {
     return WEEK.map((day, i) => {
       const date = format(
         add(currentDate, { days: -1 * getDay(currentDate) + i }),
@@ -53,7 +53,7 @@ export default function CalendarPage() {
       );
 
       return (
-        <CalenderBox day={day} date={date} key={date} todo={todos?.[date]} />
+        <CalendarBox day={day} date={date} key={date} todo={todos?.[date]} />
       );
     });
   };
@@ -68,11 +68,11 @@ export default function CalendarPage() {
     <div>
       <Container>
         <div onClick={goToday}>오늘</div>
-        <div onClick={handleLeft}>{`<`}</div>
+        <div onClick={handlePrevButtonClick}>{`<`}</div>
         {format(currentDate, "yyyy년 MM월")}
-        <div onClick={handleRight}>{`>`}</div>
+        <div onClick={handleNextButtonClick}>{`>`}</div>
       </Container>
-      <Container>{showCalender()}</Container>
+      <Container>{showCalendar()}</Container>
     </div>
   );
 }

--- a/src/components/MainMandal.js
+++ b/src/components/MainMandal.js
@@ -29,7 +29,7 @@ const BoxContatiner = styled.div`
   grid-template-columns: 1fr 1fr 1fr;
 `;
 
-export default function MainGoalPage() {
+export default function MainMandal() {
   const { id } = useParams();
   const [mandalart, setMandalart] = useState();
   const [mandalartArray, setMandalartArray] = useState([]);

--- a/src/components/MandalPage.js
+++ b/src/components/MandalPage.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
-import MainGoalPage from "./MainGoalPage";
+import MainMandal from "./MainMandal";
 import styled from "styled-components";
 import { changeToMainGoal, chageToFullView } from "../features/viewSlice";
 import { changeEditMode } from "../features/editSlice";
@@ -73,7 +73,12 @@ export default function MandalPage() {
   const handleEdit = () => {
     dispatch(changeEditMode());
   };
-  const handleShare = async () => {};
+  const handleShare = async () => {
+    await axios.post("/api/goals/mainGoal", {
+      title: "123123",
+    });
+    // await axios.get("api/todos");
+  };
   // view option 에 따라 MainGoal, SubGoal, FullView보여줌
   // 공유, 채팅, 로그아웃, 소켓 설정 예정
   return (
@@ -99,7 +104,7 @@ export default function MandalPage() {
         />
       </ButtonsContainer>
       <BodyContainer>
-        {viewOption === "mainGoal" && <MainGoalPage />}
+        {viewOption === "mainGoal" && <MainMandal />}
       </BodyContainer>
     </>
   );

--- a/src/components/MandalPage.js
+++ b/src/components/MandalPage.js
@@ -4,6 +4,7 @@ import MainGoalPage from "./MainGoalPage";
 import styled from "styled-components";
 import { changeToMainGoal, chageToFullView } from "../features/viewSlice";
 import { changeEditMode } from "../features/editSlice";
+import axios from "axios";
 
 const ButtonsContainer = styled.div`
   display: flex;
@@ -72,7 +73,7 @@ export default function MandalPage() {
   const handleEdit = () => {
     dispatch(changeEditMode());
   };
-  const handleShare = () => {};
+  const handleShare = async () => {};
   // view option 에 따라 MainGoal, SubGoal, FullView보여줌
   // 공유, 채팅, 로그아웃, 소켓 설정 예정
   return (

--- a/src/features/saga.js
+++ b/src/features/saga.js
@@ -102,7 +102,7 @@ function* loginSaga(action) {
 function* afterSuccess(user) {
   const { email, displayName, profile, newAccessToken } = user;
   yield put(loginSucceed({ email, displayName, profile }));
-  axios.defaults.headers.common["Authorization"] = `Bearer ${newAccessToken}`;
+  axios.defaults.headers.common["Authorization"] = `${newAccessToken}`;
   clearTimeout(delay);
   yield call(delay, JWT_EXPIRY_TIME - 60000);
   yield put(refresh());

--- a/src/features/saga.js
+++ b/src/features/saga.js
@@ -102,7 +102,7 @@ function* loginSaga(action) {
 function* afterSuccess(user) {
   const { email, displayName, profile, newAccessToken } = user;
   yield put(loginSucceed({ email, displayName, profile }));
-  axios.defaults.headers.common["Authorization"] = newAccessToken;
+  axios.defaults.headers.common["Authorization"] = `Bearer ${newAccessToken}`;
   clearTimeout(delay);
   yield call(delay, JWT_EXPIRY_TIME - 60000);
   yield put(refresh());


### PR DESCRIPTION
# [15] 달력페이지

## 노션 칸반 링크
- [[Task] 달력 - 기본 프레임](https://www.notion.so/vanillacoding/Task-7b41aadd4991488795d5e3e3c62dba75)

## 카드에서 구현 혹은 해결하려는 내용
- Feat: 달력 UI 생성
- 주간 이동 구현
- 오늘 클릭시 오늘 날자 이동구현
- 서버에서 해당 주간 todos data get 구현

## 테스트 방법
- 화살표 클릭 시 주간 이동 구현 확인
- 오늘 클릭시 금주 이동 확인

## 기타 사항
- UI는 차후 수정예정입니다.
- 데이터는 일주일 데이터가 `calendarPage`에서 서버에 요청하며, 해당 날자의 todos데이터는 각각 생성되는 `CalendarBox`에 props로 넘겨주게 됩니다.