### PR TITLE
[06] MainGoal 상세페이지 - 세부 항목

### DIFF
--- a/src/components/Mandal/MandalPage.js
+++ b/src/components/Mandal/MandalPage.js
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import MainMandal from "./view/MainMandal";
+import SubMandal from "./view/SubMandal";
 import styled from "styled-components";
 import { changeToMainGoal, changeToFullView } from "../../features/viewSlice";
 import { changeEditMode } from "../../features/editSlice";
+
 import axios from "axios";
 
 const ButtonsContainer = styled.div`
@@ -62,7 +64,11 @@ const ToggleLabel = styled.label`
 
 export default function MandalPage() {
   const dispatch = useDispatch();
-  const viewOption = useSelector(state => state.view.option);
+  const view = useSelector(state => state.view);
+
+  useEffect(() => {
+    dispatch(changeToMainGoal());
+  }, []);
 
   const viewCheckHandler = event => {
     event.target.checked
@@ -104,7 +110,8 @@ export default function MandalPage() {
         />
       </ButtonsContainer>
       <BodyContainer>
-        {viewOption === "mainGoal" && <MainMandal />}
+        {view.option === "mainGoal" && <MainMandal />}
+        {view.option === "subGoal" && <SubMandal selected={view.selectedId} />}
       </BodyContainer>
     </>
   );

--- a/src/components/Mandal/view/MainMandal.js
+++ b/src/components/Mandal/view/MainMandal.js
@@ -22,7 +22,7 @@ const makeArray = (mandalart, id) => {
   return tempArray;
 };
 
-const BoxContatiner = styled.div`
+const BoxContainer = styled.div`
   display: grid;
   height: 684px;
   width: 684px;
@@ -33,7 +33,9 @@ export default function MainMandal() {
   const { id } = useParams();
   const [mandalart, setMandalart] = useState();
   const [mandalartArray, setMandalartArray] = useState([]);
+
   const loginState = useSelector(state => state.user.loginSucceed);
+
   useEffect(() => {
     if (loginState) {
       const getMandalart = async () => {
@@ -65,5 +67,5 @@ export default function MainMandal() {
     });
   };
 
-  return <BoxContatiner className="gridContainer">{showBoxes()}</BoxContatiner>;
+  return <BoxContainer className="gridContainer">{showBoxes()}</BoxContainer>;
 }

--- a/src/components/Mandal/view/MandalBox.js
+++ b/src/components/Mandal/view/MandalBox.js
@@ -23,6 +23,14 @@ const InnerBox = styled.div`
   &.main {
     background-color: rgb(148, 178, 235);
   }
+
+  &.todo {
+    background-color: rgb(148, 178, 235);
+    &:hover {
+      background-color: #f4f4f4;
+      cursor: pointer;
+    }
+  }
 `;
 
 export default function MandalBox({ context, role, goalId }) {
@@ -39,7 +47,8 @@ export default function MandalBox({ context, role, goalId }) {
       if (id === event.target.id) {
         return;
       }
-      dispatch(changeToSubGoal());
+
+      dispatch(changeToSubGoal(event.target.id));
     }
   };
 

--- a/src/components/Mandal/view/SubMandal.js
+++ b/src/components/Mandal/view/SubMandal.js
@@ -1,0 +1,88 @@
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router-dom";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+import MandalBox from "./MandalBox";
+
+const BoxContainer = styled.div`
+  display: grid;
+  height: 684px;
+  width: 684px;
+  grid-template-columns: 1fr 1fr 1fr;
+`;
+
+const getMainGoal = async id => {
+  const res = await axios.get(`/api/goals/mainGoal/${id}`);
+  return res;
+};
+
+const getSubGoal = (res, id) => {
+  const { subGoals } = res.data.result.mainGoal;
+
+  for (let i = 0; i < subGoals.length; i++) {
+    if (subGoals[i]._id === id) {
+      return subGoals[i];
+    }
+  }
+};
+
+const makeArray = mandal => {
+  const results = [];
+
+  mandal.todos.forEach(({ title, level, _id }) => {
+    results.push({ title, level, _id, role: "todo" });
+  });
+
+  const { title, level } = mandal;
+  results.splice(4, 0, { title, level, _id: mandal._id, role: "sub" });
+
+  return results;
+};
+
+export default function SubMandal({ selected }) {
+  const { id } = useParams();
+  const [mandal, setMandal] = useState({});
+  const [mandalArray, setMandalArray] = useState([]);
+  const loginState = useSelector(state => state.user.loginSucceed);
+
+  useEffect(() => {
+    const getMandal = async () => {
+      const res = await getMainGoal(id);
+      setMandal(getSubGoal(res, selected));
+    };
+
+    if (loginState) {
+      getMandal();
+    }
+  }, [loginState]);
+
+  useEffect(() => {
+    if (!Object.keys(mandal).length) {
+      return;
+    }
+
+    setMandalArray(makeArray(mandal));
+  }, [mandal]);
+
+  const showBoxes = () => {
+    return mandalArray.map(box => {
+      return (
+        <MandalBox
+          context={String(box.title)}
+          role={box.role}
+          key={box["_id"]}
+          goalId={box["_id"]}
+        />
+      );
+    });
+  };
+
+  return <BoxContainer className="gridContainer">{showBoxes()}</BoxContainer>;
+}
+
+SubMandal.propTypes = {
+  selected: PropTypes.string.isRequired,
+};

--- a/src/components/MyGoals/MyGoalsList.js
+++ b/src/components/MyGoals/MyGoalsList.js
@@ -23,6 +23,7 @@ export default function MyGoalsList() {
 
   const getData = async () => {
     const { data } = await goalApi();
+    console.log(data.result);
     setData(data.result);
     setIsLoading(false);
   };

--- a/src/features/viewSlice.js
+++ b/src/features/viewSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
   option: "mainGoal",
+  selectedId: "",
 };
 
 export const viewSlice = createSlice({
@@ -10,12 +11,15 @@ export const viewSlice = createSlice({
   reducers: {
     changeToMainGoal: state => {
       state.option = "mainGoal";
+      state.selectedId = "";
     },
-    changeToSubGoal: state => {
+    changeToSubGoal: (state, action) => {
       state.option = "subGoal";
+      state.selectedId = action.payload;
     },
     changeToFullView: state => {
       state.option = "fullView";
+      state.selectedId = "";
     },
   },
 });


### PR DESCRIPTION
# [06] MainGoal 상세페이지 - 세부 항목

## 노션 칸반 링크

- [[06] MainGoal 상세페이지 - 세부 항목](https://www.notion.so/vanillacoding/Task-GET-MainGoal-fab2a338126d43d1bdc4b875d1e982d4)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: MainGoal 상세페이지 세부항목 subGoal 뷰 페이지

- 기존 MainGoal 상세페이지
![image](https://user-images.githubusercontent.com/82270552/153434388-ae7272d3-d7b5-4d83-88be-6d3b79b22384.png)

- 위 화면에서 바깥 회색 영역(서브골 1, 2, 3) 클릭 시 아래 화면으로 전환
![image](https://user-images.githubusercontent.com/82270552/153434530-a3de113a-c06e-46f1-a8c1-6fd70ff21307.png)

## 기타 사항

- MainMandal과 SubMandal에 겹치는 로직이 많아 함께 리팩토링이 필요합니다.
- MainMandal과 SubMandal을 하나로 관리할 수는 없을까 고민이 되네요.