### PR TITLE
[53] MainGoal 상세페이지 리팩토링

### DIFF
--- a/src/components/Mandal/MandalPage.js
+++ b/src/components/Mandal/MandalPage.js
@@ -6,7 +6,7 @@ import axios from "axios";
 import MainMandal from "./view/MainMandal";
 import SubMandal from "./view/SubMandal";
 
-import { changeToMainGoal, changeToFullView } from "../../features/viewSlice";
+import { displayMain, displayFull } from "../../features/viewSlice";
 import { changeEditMode } from "../../features/editSlice";
 
 const ButtonsContainer = styled.div`
@@ -68,16 +68,14 @@ const ToggleLabel = styled.label`
 
 export default function MandalPage() {
   const dispatch = useDispatch();
-  const view = useSelector(state => state.view);
+  const viewOption = useSelector(state => state.mandal.option);
 
   useEffect(() => {
-    dispatch(changeToMainGoal());
+    dispatch(displayMain());
   }, []);
 
   const viewCheckHandler = event => {
-    event.target.checked
-      ? dispatch(changeToFullView())
-      : dispatch(changeToMainGoal());
+    event.target.checked ? dispatch(displayFull()) : dispatch(displayMain());
   };
 
   const handleEdit = () => {
@@ -114,8 +112,8 @@ export default function MandalPage() {
         />
       </ButtonsContainer>
       <BodyContainer>
-        {view.option === "mainGoal" && <MainMandal />}
-        {view.option === "subGoal" && <SubMandal selected={view.selectedId} />}
+        {viewOption === "mainGoal" && <MainMandal />}
+        {viewOption === "subGoal" && <SubMandal />}
       </BodyContainer>
     </>
   );

--- a/src/components/Mandal/view/MainMandal.js
+++ b/src/components/Mandal/view/MainMandal.js
@@ -1,22 +1,18 @@
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import axios from "axios";
 
 import MandalBox from "./MandalBox";
+import { getMandal, displaySub } from "../../../features/viewSlice";
 
-const getMainGoal = async id => {
-  const res = await axios.get(`/api/goals/mainGoal/${id}`);
-  return res;
-};
-
-const makeArray = (mandalart, id) => {
+const makeArray = (mandal, id) => {
   const tempArray = [];
-  mandalart.subGoals.forEach(({ title, level, _id }) => {
+  mandal.subGoals.forEach(({ title, level, _id }) => {
     tempArray.push({ title, level, _id, role: "sub" });
   });
-  const { title, level } = mandalart;
+  const { title, level } = mandal;
   tempArray.splice(4, 0, { title, level, _id: id, role: "main" });
 
   return tempArray;
@@ -31,37 +27,50 @@ const BoxContainer = styled.div`
 
 export default function MainMandal() {
   const { id } = useParams();
-  const [mandalart, setMandalart] = useState();
-  const [mandalartArray, setMandalartArray] = useState([]);
-
+  const dispatch = useDispatch();
+  const data = useSelector(state => state.mandal.displayed);
   const loginState = useSelector(state => state.user.loginSucceed);
+  const isEditMode = useSelector(state => state.edit.mode);
+  const [mandalArray, setMandalArray] = useState([]);
 
   useEffect(() => {
     if (loginState) {
-      const getMandalart = async () => {
-        const res = await getMainGoal(id);
-        setMandalart(res.data.result.mainGoal);
-      };
-      getMandalart();
+      dispatch(getMandal(id));
     }
   }, [loginState]);
 
   useEffect(() => {
-    if (!mandalart) {
+    if (!Object.keys(data).length) {
       return;
     }
 
-    setMandalartArray(makeArray(mandalart, id));
-  }, [mandalart]);
+    setMandalArray(makeArray(data, id));
+  }, [data]);
+
+  const handleBoxClick = (event, index) => {
+    if (isEditMode) {
+      if (id !== event.target.id) {
+        return;
+      }
+      // 수정기능 추가
+    } else {
+      if (id === event.target.id) {
+        return;
+      }
+
+      dispatch(displaySub(index));
+    }
+  };
 
   const showBoxes = () => {
-    return mandalartArray.map(box => {
+    return mandalArray.map((box, index) => {
       return (
         <MandalBox
           context={String(box.title)}
           role={box.role}
           key={box["_id"]}
           goalId={box["_id"]}
+          onClick={event => handleBoxClick(event, index)}
         />
       );
     });

--- a/src/components/Mandal/view/MandalBox.js
+++ b/src/components/Mandal/view/MandalBox.js
@@ -1,10 +1,6 @@
 import React from "react";
-import { useParams } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-
-import { changeToSubGoal } from "../../../features/viewSlice";
 
 const InnerBox = styled.div`
   /* width: 100px;
@@ -35,27 +31,10 @@ const InnerBox = styled.div`
   }
 `;
 
-export default function MandalBox({ context, role, goalId }) {
-  const { id } = useParams();
-  const dispatch = useDispatch();
-  const isEditMode = useSelector(state => state.edit.mode);
-  const handleClickBox = event => {
-    if (isEditMode) {
-      if (id !== event.target.id) {
-        return;
-      }
-      // 수정기능 추가
-    } else {
-      if (id === event.target.id) {
-        return;
-      }
-
-      dispatch(changeToSubGoal(event.target.id));
-    }
-  };
-
+// MandalBox가 handleClick props 내려받을 수 있도록 (MandalPage에서)
+export default function MandalBox({ context, role, goalId, onClick }) {
   return (
-    <InnerBox className={role} onClick={handleClickBox} id={goalId}>
+    <InnerBox className={role} onClick={onClick} id={goalId}>
       {context}
     </InnerBox>
   );
@@ -65,4 +44,5 @@ MandalBox.propTypes = {
   context: PropTypes.string.isRequired,
   role: PropTypes.string.isRequired,
   goalId: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
 };

--- a/src/components/Mandal/view/SubMandal.js
+++ b/src/components/Mandal/view/SubMandal.js
@@ -1,11 +1,9 @@
-import axios from "axios";
 import React, { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
-import PropTypes from "prop-types";
 
 import MandalBox from "./MandalBox";
+import { displayMain } from "../../../features/viewSlice";
 
 const BoxContainer = styled.div`
   display: grid;
@@ -13,21 +11,6 @@ const BoxContainer = styled.div`
   width: 684px;
   grid-template-columns: 1fr 1fr 1fr;
 `;
-
-const getMainGoal = async id => {
-  const res = await axios.get(`/api/goals/mainGoal/${id}`);
-  return res;
-};
-
-const getSubGoal = (res, id) => {
-  const { subGoals } = res.data.result.mainGoal;
-
-  for (let i = 0; i < subGoals.length; i++) {
-    if (subGoals[i]._id === id) {
-      return subGoals[i];
-    }
-  }
-};
 
 const makeArray = mandal => {
   const results = [];
@@ -42,39 +25,34 @@ const makeArray = mandal => {
   return results;
 };
 
-export default function SubMandal({ selected }) {
-  const { id } = useParams();
-  const [mandal, setMandal] = useState({});
+export default function SubMandal() {
   const [mandalArray, setMandalArray] = useState([]);
-  const loginState = useSelector(state => state.user.loginSucceed);
+  const data = useSelector(state => state.mandal.displayed);
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    const getMandal = async () => {
-      const res = await getMainGoal(id);
-      setMandal(getSubGoal(res, selected));
-    };
-
-    if (loginState) {
-      getMandal();
-    }
-  }, [loginState]);
-
-  useEffect(() => {
-    if (!Object.keys(mandal).length) {
+    if (!Object.keys(data).length) {
       return;
     }
 
-    setMandalArray(makeArray(mandal));
-  }, [mandal]);
+    setMandalArray(makeArray(data));
+  }, [data]);
+
+  const handleBoxClick = index => {
+    if (index === 4) {
+      dispatch(displayMain());
+    }
+  };
 
   const showBoxes = () => {
-    return mandalArray.map(box => {
+    return mandalArray.map((box, index) => {
       return (
         <MandalBox
           context={String(box.title)}
           role={box.role}
           key={box["_id"]}
           goalId={box["_id"]}
+          onClick={() => handleBoxClick(index)}
         />
       );
     });
@@ -82,7 +60,3 @@ export default function SubMandal({ selected }) {
 
   return <BoxContainer className="gridContainer">{showBoxes()}</BoxContainer>;
 }
-
-SubMandal.propTypes = {
-  selected: PropTypes.string.isRequired,
-};

--- a/src/features/viewSlice.js
+++ b/src/features/viewSlice.js
@@ -2,28 +2,34 @@ import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
   option: "mainGoal",
-  selectedId: "",
+  data: {},
+  displayed: {},
 };
 
 export const viewSlice = createSlice({
   name: "view",
   initialState,
   reducers: {
-    changeToMainGoal: state => {
+    getMandal: state => state,
+    setMandal: (state, action) => {
+      state.data = action.payload;
+      state.displayed = action.payload;
+    },
+    displayMain: state => {
       state.option = "mainGoal";
-      state.selectedId = "";
+      state.displayed = state.data;
     },
-    changeToSubGoal: (state, action) => {
+    displayFull: state => {
+      state.option = "full";
+      state.displayed = state.data;
+    },
+    displaySub: (state, action) => {
       state.option = "subGoal";
-      state.selectedId = action.payload;
-    },
-    changeToFullView: state => {
-      state.option = "fullView";
-      state.selectedId = "";
+      state.displayed = state.data.subGoals[action.payload];
     },
   },
 });
 
-export const { changeToMainGoal, changeToSubGoal, changeToFullView } =
+export const { getMandal, setMandal, displayMain, displaySub, displayFull } =
   viewSlice.actions;
 export default viewSlice.reducer;

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -4,6 +4,7 @@ import rootSaga from "../features/saga";
 import userReducer from "../features/userSlice";
 import viewReducer from "../features/viewSlice";
 import editReducer from "../features/editSlice";
+import mandalReducer from "../features/viewSlice";
 
 const sagaMiddleware = createSagaMiddleware();
 
@@ -12,6 +13,7 @@ export const store = configureStore({
     user: userReducer,
     view: viewReducer,
     edit: editReducer,
+    mandal: mandalReducer,
   },
   middleware: [sagaMiddleware],
 });


### PR DESCRIPTION
# [53] MainGoal 상세페이지 리팩토링

## 노션 칸반 링크

- [MainGoal 상세페이지 리팩토링](https://www.notion.so/vanillacoding/Task-MainGoal-38e4136bebf14e159d549f4a881a70f3)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: viewSlice 상태 및 액션 추가, saga 추가
- Refactor: viewSlice 액션 수정
- Refactor: MandalBox onClick prop 추가, Main/SubMandal 단위에서 이벤트 핸들러 내려주도록 변경
- Feat: SubMandal에서 중앙 요소 클릭 시 Main으로 돌아가는 기능 추가
