### PR TITLE
[70] Fullview UI 버그 수정

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -3,7 +3,7 @@
   box-sizing: border-box;
 }
 
-body, li, ul {
+body, li, ul, p {
   margin: 0;
   padding: 0;
 }

--- a/src/components/Calendar/CalendarPage.js
+++ b/src/components/Calendar/CalendarPage.js
@@ -10,10 +10,9 @@ const CalendarHeader = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 5px;
+  margin: 20px 0;
 
   .today-button {
-    margin: 10px;
     padding: 10px 25px;
     border: 1px solid rgb(148, 178, 235);
     border-radius: 6px;
@@ -33,7 +32,6 @@ const CalendarHeader = styled.div`
   .prev-button,
   .next-button {
     margin: 0 10px;
-    padding: 10px;
     width: 20px;
     height: 20px;
 

--- a/src/components/Calendar/Day.js
+++ b/src/components/Calendar/Day.js
@@ -10,26 +10,21 @@ const DayContainer = styled.div`
   height: 70vh;
   text-align: center;
   border: 1px solid #e9e9e9;
-`;
-
-const DayWrapper = styled.div`
-  padding-top: 5px;
-  background-color: rgb(148, 178, 235);
-`;
-
-const DateWrapper = styled.div`
-  display: flex;
-  justify-content: center;
   border-collapse: collapse;
-  background-color: white;
-  text-align: center;
+`;
+
+const DayWrapper = styled.p`
+  font-size: 20px;
+`;
+
+const DateWrapper = styled.p`
   font-size: 25px;
-  background-color: rgb(148, 178, 235);
-  padding-bottom: 5px;
 `;
 
 const DateContainer = styled.div`
-  border: none;
+  background-color: rgb(148, 178, 235);
+  padding: 5px;
+  text-align: center;
 `;
 
 const TodoWrapper = styled.div`

--- a/src/components/Calendar/Todo.js
+++ b/src/components/Calendar/Todo.js
@@ -10,13 +10,14 @@ import { changeCompletion } from "../../reducers/todoSlice";
 const randomColor = parseInt(Math.random() * 0xffffff).toString(16);
 
 const TodoContainer = styled.div`
+  width: 100%;
   display: flex;
   justify-content: start;
   align-items: center;
-  margin-bottom: 5px;
-  border: none;
+  margin-bottom: 3px;
+  padding: 10px;
+  background-color: ${`#${randomColor}`};
   border-radius: 4px;
-  background-color: "#" + ${randomColor};
 
   &:hover {
     border: 1px solid black;
@@ -26,8 +27,10 @@ const TodoContainer = styled.div`
 `;
 
 const Title = styled.p`
+  margin: 0;
   font-size: 20x;
   color: black;
+  word-break: break-all;
 
   &.complete {
     font-size: 20x;
@@ -37,11 +40,9 @@ const Title = styled.p`
 `;
 
 const CheckButton = styled.img`
-  display: flex;
-  align-items: center;
   width: 18%;
   height: 18%;
-  margin: 0 12px;
+  margin: 0 5px;
 `;
 
 export default function Todo({ todo, date }) {

--- a/src/components/Chat/Chatroom.js
+++ b/src/components/Chat/Chatroom.js
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 import Loading from "../shared/Loading";
 import MessageBox from "./MessageBox";
 
-const socket = io.connect(process.env.REACT_APP_URL);
+const socket = io.connect(process.env.REACT_APP_PRODUCT_AXIOS_BASEURL);
 
 const ChatRoomContainer = styled.div`
   width: 100%;

--- a/src/components/Chat/Chatroom.js
+++ b/src/components/Chat/Chatroom.js
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from "uuid";
 import Loading from "../shared/Loading";
 import MessageBox from "./MessageBox";
 
-const socket = io.connect(process.env.REACT_APP_PRODUCT_AXIOS_BASEURL);
+const socket = io.connect(process.env.REACT_APP_URL);
 
 const ChatRoomContainer = styled.div`
   width: 100%;

--- a/src/components/Mandal/MandalPage.js
+++ b/src/components/Mandal/MandalPage.js
@@ -24,9 +24,7 @@ const ButtonsContainer = styled.div`
   align-items: center;
   width: 400px;
   height: 50px;
-  margin-bottom: 10px;
-  margin-right: auto;
-  margin-left: auto;
+  margin: 10px auto;
 `;
 
 const EditButton = styled.img`
@@ -37,17 +35,10 @@ const EditButton = styled.img`
   background-color: ${props => props.selected && "rgba(148, 178, 235, 0.5)"};
 `;
 
-const BodyContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  height: 70vh;
-`;
-
 const BoxContainer = styled.div`
-  height: 684px;
-  width: 684px;
+  margin: 0 auto;
+  width: 70vh;
+  height: 70vh;
 `;
 
 const ToggleButton = styled.input`
@@ -151,17 +142,15 @@ export default function MandalPage() {
       </div>
       {isFetching && <div>Loading...</div>}
       {!isFetching && (
-        <BodyContainer>
-          <BoxContainer>
-            {viewOption === VIEW_OPTION.MAIN_VIEW && (
-              <MainMandal data={mandalArray} />
-            )}
-            {viewOption === VIEW_OPTION.SUB_VIEW && (
-              <SubMandal data={mandalArray} />
-            )}
-            {viewOption === VIEW_OPTION.FULL_VIEW && <FullView />}
-          </BoxContainer>
-        </BodyContainer>
+        <BoxContainer>
+          {viewOption === VIEW_OPTION.MAIN_VIEW && (
+            <MainMandal data={mandalArray} />
+          )}
+          {viewOption === VIEW_OPTION.SUB_VIEW && (
+            <SubMandal data={mandalArray} />
+          )}
+          {viewOption === VIEW_OPTION.FULL_VIEW && <FullView />}
+        </BoxContainer>
       )}
       {isEditMode && <ChatPage />}
     </>

--- a/src/components/Mandal/view/FullView.js
+++ b/src/components/Mandal/view/FullView.js
@@ -6,30 +6,26 @@ import MainMandal from "./MainMandal";
 import SubMandal from "./SubMandal";
 
 const MandalContainer = styled.div`
-  display: grid;
+  display: inline-grid;
   height: 100%;
   width: 100%;
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 1fr 1fr 1fr;
 
-  & :nth-child(3n) {
-    border-left: solid #e6e6e6 1px;
+  > div:nth-child(3n) {
+    border-left: 1px solid #e6e6e6;
   }
 
-  & :nth-child(-n + 3) {
-    border-bottom: solid #e6e6e6 1px;
+  > div:nth-child(-n + 3) {
+    border-bottom: 1px solid #e6e6e6;
   }
 
-  & :nth-child(3n + 1) {
-    border-right: solid #e6e6e6 1px;
+  > div:nth-child(3n + 1) {
+    border-right: 1px solid #e6e6e6;
   }
 
-  & :nth-child(3n) {
-    border-left: solid #e6e6e6 1px;
-  }
-
-  & :nth-child(n + 7) {
-    border-top: solid #e6e6e6 1px;
+  > div:nth-child(n + 7) {
+    border-top: 1px solid #e6e6e6;
   }
 `;
 

--- a/src/components/Mandal/view/MainMandal.js
+++ b/src/components/Mandal/view/MainMandal.js
@@ -9,14 +9,11 @@ import { showBoxes } from "./utils";
 import { VIEW_OPTION } from "../../../constants";
 
 const BoxContainer = styled.div`
-  display: grid;
-  height: 100%;
-  width: 100%;
+  display: inline-grid;
+  height: ${props => props.size};
+  width: ${props => props.size};
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 1fr 1fr 1fr;
-  & :nth-child(n) {
-    border: none;
-  }
 `;
 
 export default function MainMandal({ data }) {
@@ -44,7 +41,10 @@ export default function MainMandal({ data }) {
   };
 
   return (
-    <BoxContainer className="gridContainer">
+    <BoxContainer
+      className="gridContainer"
+      size={viewOption === VIEW_OPTION.FULL_VIEW ? "25vh" : "70vh"}
+    >
       {showBoxes(data, handleBoxClick)}
     </BoxContainer>
   );

--- a/src/components/Mandal/view/MandalBox.js
+++ b/src/components/Mandal/view/MandalBox.js
@@ -9,8 +9,13 @@ import { VIEW_OPTION } from "../../../constants";
 import { modifyMandal } from "../../../reducers/mandalSlice";
 
 const InnerBox = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   border-radius: 10%;
-  margin: 10px;
+  margin: 5px;
+  padding: 3px;
+  overflow: hidden;
 
   &.subGoals,
   &.todos {
@@ -30,9 +35,10 @@ const InnerBox = styled.div`
   }
 `;
 
-const Content = styled.div`
+const Content = styled.p`
   text-align: center;
-  outline: none;
+  word-break: break-all;
+  font-size: ${props => props.fontSize};
 `;
 
 export default function MandalBox({ content, role, goalId, onClick }) {
@@ -81,6 +87,7 @@ export default function MandalBox({ content, role, goalId, onClick }) {
         onInput={handleContent}
         spellCheck={false}
         dangerouslySetInnerHTML={{ __html: content }}
+        fontSize={viewOption === VIEW_OPTION.FULL_VIEW ? "7px" : "1em"}
       />
     </InnerBox>
   );

--- a/src/components/Mandal/view/SubMandal.js
+++ b/src/components/Mandal/view/SubMandal.js
@@ -8,17 +8,13 @@ import { showBoxes } from "./utils";
 import { VIEW_OPTION } from "../../../constants";
 import Modal from "../../Modal";
 import Todo from "./Todo";
-import ChatPage from "../../Chat/ChatPage";
 
 const BoxContainer = styled.div`
-  display: grid;
-  height: 100%;
-  width: 100%;
+  display: inline-grid;
+  height: ${props => props.size};
+  width: ${props => props.size};
   grid-template-columns: 1fr 1fr 1fr;
   grid-template-rows: 1fr 1fr 1fr;
-  & :nth-child(n) {
-    border: none;
-  }
 `;
 
 export default function SubMandal({ data, mandalIndex }) {
@@ -51,10 +47,12 @@ export default function SubMandal({ data, mandalIndex }) {
 
   return (
     <>
-      <BoxContainer className="gridContainer">
+      <BoxContainer
+        className="gridContainer"
+        size={viewOption === VIEW_OPTION.FULL_VIEW ? "25vh" : "70vh"}
+      >
         {showBoxes(data, handleBoxClick)}
       </BoxContainer>
-      <ChatPage />
       {showModal && (
         <Modal
           onClick={() => setShowModal(!showModal)}

--- a/src/components/MyGoals/MyGoalsEntry.js
+++ b/src/components/MyGoals/MyGoalsEntry.js
@@ -19,6 +19,7 @@ const ThumbnailContainer = styled.div`
   text-align: center;
   background-color: rgb(148, 178, 235);
   border-radius: 5px;
+  overflow: auto;
 
   .delete-button {
     display: none;


### PR DESCRIPTION
# [70] Fullview UI 버그 수정

## 노션 칸반 링크

- [[70] Fullview UI 버그 수정](https://www.notion.so/vanillacoding/Fix-Fullview-UI-cae84bfba39e465480d6772680f675f8)

## 카드에서 구현 혹은 해결하려는 내용

- Fix: 달력 Todo 랜덤 배경색 미적용 버그 수정
- Fix: 달력 헤더 화살표 버튼 안 보이는 버그 수정
- Design: Day CSS 여백 등 수정
- Feat: MainGoalLists에서 overflow hidden 추가
- Fix: FullView 모드에서 글자 수, 그리드 넘치는 문제 해결

![image](https://user-images.githubusercontent.com/82270552/154428420-50cdae61-46af-4079-aeb5-8f00edf3a596.png)
![image](https://user-images.githubusercontent.com/82270552/154428445-e7d8aad2-fb5f-4ebe-80d0-a52c0db6d470.png)


## 기타 사항

- 만다라트 내 컨텐츠 컨테이너가 기존 div 태그에서 p 태그로 변경.
- 기존
```
<div>
  <div contentEditable>title</div>
<div>
```
- 수정
```
<div>
  <p contentEditable>title</p>
<div>
```