### PR TITLE
[71] socket 배포 에러 수정 2

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -4,7 +4,6 @@ import { useDispatch, useSelector } from "react-redux";
 import axios from "axios";
 
 import { refresh } from "../reducers/userSlice";
-
 import IndexPage from "../components/IndexPage";
 import GlobalNavBar from "../components/Header/GlobalNavBar";
 import Navbar from "../components/Header/Navbar";

--- a/src/components/Mandal/view/MandalBox.js
+++ b/src/components/Mandal/view/MandalBox.js
@@ -39,6 +39,7 @@ const Content = styled.p`
   text-align: center;
   word-break: break-all;
   font-size: ${props => props.fontSize};
+  outline: none;
 `;
 
 export default function MandalBox({ content, role, goalId, onClick }) {

--- a/src/features/socket.js
+++ b/src/features/socket.js
@@ -1,6 +1,8 @@
 import io from "socket.io-client";
-export const socket = io.connect();
-// export const socket = io.connect(process.env.REACT_APP_PRODUCT_AXIOS_BASEURL);
+export const socket = io.connect(process.env.REACT_APP_PRODUCT_AXIOS_BASEURL, {
+  transports: ["websocket"],
+  cors: { origin: process.env.REACT_APP_PRODUCT_AXIOS_BASEURL },
+});
 
 export const socketAction = {
   joinMandal: id => {

--- a/src/sagas/todoSaga.test.js
+++ b/src/sagas/todoSaga.test.js
@@ -1,7 +1,8 @@
 import { expectSaga } from "redux-saga-test-plan";
-import { getTodosSaga, getTodosAPI } from "./todoSaga";
+import { watchGetTodos, getTodosSaga, getTodosAPI } from "./todoSaga";
 import { call, put } from "redux-saga/effects";
 import {
+  getTodos,
   getTodosSuccess,
   getTodosError,
   setTodos,
@@ -21,11 +22,23 @@ it("get todos Success", () => {
     },
   };
 
-  return expectSaga(getTodosSaga, action)
-    .provide([[call(getTodosAPI, action.payload), res]])
-    .put({ type: setTodos.type, payload: "fake todo" })
-    .dispatch({ type: getTodosSuccess.type })
-    .run();
+  // return expectSaga(getTodosSaga, action)
+  //   .provide([[call(getTodosAPI, action.payload), res]])
+  //   .put({ type: setTodos.type, payload: "fake todo" })
+  //   .dispatch({ type: getTodosSuccess.type })
+  //   .run();
+
+  return (
+    expectSaga(watchGetTodos)
+      .withReducer(getTodos)
+      // (getTodosSaga, action)
+      // .dispatch({ type: getTodos.type }, action)
+      // .provide()
+      .provide([[call(getTodosAPI, action.payload), res]])
+      .put({ type: setTodos.type, payload: "fake todo" })
+      .dispatch({ type: getTodosSuccess.type })
+      .run()
+  );
 });
 
 it("get todos Failure", () => {


### PR DESCRIPTION
# [71] socket배포 에러 2

## 노션 칸반 링크
- [[Task] 프론트 +백엔드 배포 - HTTPS 해결](https://www.notion.so/vanillacoding/Task-HTTPS-5e2c67fe31174241a4e1aa2fdaa0c24a)

## 카드에서 구현 혹은 해결하려는 내용
- fix: 소켓 https에러 관련 수정2

