### PR TITLE
[73] 만다라트 사이드 클릭 불가, Netlify 경로 이슈

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,8 @@
 [context.production.environment]
   TOML_ENV_VAR = "From netlify.toml"
   REACT_APP_TOML_ENV_VAR = "From netlify.toml (REACT_APP_)"
+
+[[redirects]]
+  from = "/"
+  to = "/"
+  status = 200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+* /index.html 200

--- a/src/components/Chat/ChatPage.js
+++ b/src/components/Chat/ChatPage.js
@@ -5,13 +5,16 @@ import Chatroom from "./Chatroom";
 import MessageInput from "./MessageInput";
 
 const ChatPageContainer = styled.div`
+  /* position: fixed; */
+  /* top: 20%; */
   position: fixed;
-  top: 20%;
+  bottom: 0;
 `;
 
 const ChatModalContainer = styled.div`
   position: relative;
-  visibility: ${props => (props.isOpen ? "visible" : "hidden")};
+  /* visibility: ${props => (props.isOpen ? "visible" : "hidden")}; */
+  display: ${props => (props.isOpen ? "block" : "none")};
   width: 300px;
   height: 70vh;
   border: 1px solid #848484;
@@ -20,7 +23,6 @@ const ChatModalContainer = styled.div`
 `;
 
 const ChatOpenButton = styled.div`
-  position: relative;
   width: 30px;
   height: 30px;
   background: #ffffff;


### PR DESCRIPTION
# [73] 만다라트 사이드 클릭 불가, Netlify 경로 이슈

## 노션 칸반 링크

- [[73] 만다라트 사이드 클릭 불가, Netlify 경로 이슈](https://www.notion.so/vanillacoding/Fix-8e3768867f2b4a9d80375b919a1476ad)

## 카드에서 구현 혹은 해결하려는 내용

- Fix: ChatPage 내 컨테이너 display, visibility 옵션 수정
- Fix: Netlify SPA 경로 설정 관련 옵션 추가
