### PR TITLE
[74] todo 태그 노출되는 이슈 수정

### DIFF
--- a/src/components/Mandal/view/MandalBox.js
+++ b/src/components/Mandal/view/MandalBox.js
@@ -62,7 +62,7 @@ export default function MandalBox({ content, role, goalId, onClick }) {
   // }, 500); // 디바운스 관련 차후 수정 예정
 
   const handleContent = async event => {
-    const newText = event.currentTarget.innerHTML;
+    const newText = event.currentTarget.innerText.replace(/[\r\n]+/gm, " ");
 
     if (viewOption === VIEW_OPTION.FULL_VIEW) {
       return;
@@ -87,9 +87,10 @@ export default function MandalBox({ content, role, goalId, onClick }) {
         onBlur={handleContent}
         onInput={handleContent}
         spellCheck={false}
-        dangerouslySetInnerHTML={{ __html: content }}
         fontSize={viewOption === VIEW_OPTION.FULL_VIEW ? "7px" : "1em"}
-      />
+      >
+        {content}
+      </Content>
     </InnerBox>
   );
 }


### PR DESCRIPTION
# [74] todo 태그 노출되는 이슈 수정

## 노션 칸반 링크

- [[74] todo 태그 노출되는 이슈 수정](https://www.notion.so/vanillacoding/Fix-Todo-br-04e79dd8f61844ada56431ca9b23d679)

## 카드에서 구현 혹은 해결하려는 내용

- Fix: todo 관련 태그 노출되는 이슈 수정
- Change: 에딧 모드에서 텍스트 수정 시 newline 공백으로 대체하도록 handleContent 로직 추가

## 기타 사항

- DB에 저장하기 전 컨텐츠를 다듬는 로직을 수정한 것이므로, todo 등에서 보여주는 부분에는 변경이 없습니다.
- 기존 DB에 태그를 포함하여 저장된 데이터의 경우 `<br>`, `<div>` 등이 그대로 노출됩니다.
