### PR TITLE
[75] 채팅 UI, 만달 클릭 이벤트 수정

### DIFF
--- a/src/components/Chat/MessageBox.js
+++ b/src/components/Chat/MessageBox.js
@@ -58,7 +58,6 @@ const MessageWrapper = styled.div`
 
 const DateWrapper = styled.div`
   width: 100%;
-  text-align: right;
 
   span {
     font-size: 13px;

--- a/src/components/Chat/MessageInput.js
+++ b/src/components/Chat/MessageInput.js
@@ -39,8 +39,8 @@ export default function MessageInput() {
   const [message, setMessage] = useState("");
   const { id } = useParams();
 
-  const currenDate = new Date();
-  const createdAt = format(currenDate, "yyyy.MM.dd HH:mm");
+  const currentDate = new Date();
+  const createdAt = format(currentDate, "yyyy.MM.dd HH:mm");
 
   const handleSendButtonClick = async () => {
     await axios.post(`/api/chats/${id}`, {

--- a/src/components/Mandal/MandalHeader/ShareButton.js
+++ b/src/components/Mandal/MandalHeader/ShareButton.js
@@ -7,6 +7,7 @@ const ShareContainer = styled.div`
   position: relative;
   width: 50px;
   height: 50px;
+  cursor: pointer;
 
   img {
     width: 100%;

--- a/src/components/Mandal/view/MainMandal.js
+++ b/src/components/Mandal/view/MainMandal.js
@@ -23,6 +23,8 @@ export default function MainMandal({ data }) {
   const viewOption = useSelector(state => state.mandal.option);
 
   const handleBoxClick = (event, index) => {
+    event.stopPropagation();
+
     if (viewOption === VIEW_OPTION.FULL_VIEW) {
       dispatch(displayMain());
       return;

--- a/src/components/Mandal/view/MandalBox.js
+++ b/src/components/Mandal/view/MandalBox.js
@@ -82,6 +82,8 @@ export default function MandalBox({ content, role, goalId, onClick }) {
   return (
     <InnerBox className={role} onClick={onClick} id={goalId} ref={box}>
       <Content
+        onClick={onClick}
+        id={goalId}
         contentEditable={isEditMode}
         suppressContentEditableWarning={true}
         onBlur={handleContent}


### PR DESCRIPTION
# [75] 채팅 UI, 만달 클릭 이벤트 수정

## 노션 칸반 링크

- [[75] 채팅 UI, 만달 클릭 이벤트 수정](https://www.notion.so/vanillacoding/Fix-c627d32bf81a4666b1f02d679330d80f)

## 카드에서 구현 혹은 해결하려는 내용

- Design: 채팅 메시지 박스에 시간 표기 위치 수정
- Feat: 공유하기 버튼에 커서 css 추가
- Feat: HalfView 모드에서 만달 텍스트에 뷰 이동 이벤트 추가

## 기타 사항

- 실서버 채팅 딜레이 이슈는 채팅 소켓 변경 부분 실서버 반영 후 재확인 예정

