### PR TITLE
[79] [Fix] 프론트엔드 소켓 오류 - 만달/채팅

### DIFF
--- a/src/components/Mandal/MandalPage.js
+++ b/src/components/Mandal/MandalPage.js
@@ -8,7 +8,7 @@ import {
   displayFull,
   getMandal,
 } from "../../reducers/mandalSlice";
-import { changeEditMode } from "../../reducers/editSlice";
+import { changeEditMode, leaveEditMode } from "../../reducers/editSlice";
 import { initializeGoalError } from "../../reducers/goalListSlice";
 import { initializeMandalError } from "../../reducers/mandalSlice";
 import { initializeTodosError } from "../../reducers/todoSlice";
@@ -102,6 +102,10 @@ export default function MandalPage() {
       dispatch(displayMain());
     }
     dispatch(getMandal(id));
+
+    return () => {
+      dispatch(leaveEditMode());
+    };
   }, []);
 
   useEffect(() => {

--- a/src/reducers/editSlice.js
+++ b/src/reducers/editSlice.js
@@ -11,8 +11,11 @@ export const editSlice = createSlice({
     changeEditMode: state => {
       state.mode = !state.mode;
     },
+    leaveEditMode: state => {
+      state.mode = false;
+    },
   },
 });
 
-export const { changeEditMode } = editSlice.actions;
+export const { changeEditMode, leaveEditMode } = editSlice.actions;
 export default editSlice.reducer;


### PR DESCRIPTION
# [79] [Fix] 프론트엔드 소켓 오류 - 만달/채팅

## 노션 칸반 링크

- [[79] [Fix] 프론트엔드 소켓 오류 - 만달/채팅](https://www.notion.so/vanillacoding/Fix-dabec2b49e6649089a5a540879fbf414)

## 카드에서 구현 혹은 해결하려는 내용

- Feat: leaveEditMode 액션 추가
- Fix: 소켓 오류 수정

## 기타 사항

- 채팅이 다른 방에 전송되거나 일시적으로 다른 방의 만달 수정 내역이 보이는 오류가 있었음
- 항상 발생하는 오류가 아니라 특수한 조건에서 관찰됨
- 조건 : 수정모드 활성화 후 수정모드를 끄지 않고 다른 페이지로 이동했을 때로 추정
- 해결 : 만달 상세페이지 컴포넌트(MandalPage)가 언마운트될 때 수정모드 비활성화 강제하는 로직 추가.
